### PR TITLE
srtm1 for create_output*.py

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
 testing/*
 #.gitignore
 *.sdf
+*.csv

--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,3 @@
+testing/*
+#.gitignore
+*.sdf

--- a/create_output.py
+++ b/create_output.py
@@ -6,7 +6,7 @@ splat_list = []
 # receive_sensitivity = '-120'
 
 
-def create(file_name, receive_sensitivity):
+def create(file_name, receive_sensitivity, definition):
 
     #create ppm and KML
     #cpk = 'splat -t ' + file_name + ' -o -c 2.0 '+ file_name + '.ppm -ngs -kml -metric'

--- a/create_output.py
+++ b/create_output.py
@@ -101,7 +101,7 @@ def convert(file_name, receive_sensitivity):
 
     #wld2gtif = 'gdalwarp ' + file_name + '.png ' + file_name + '.tif'
 
-    wld2gtif = 'gdal_translate -a_nodata 255 -expand gray -of GTiff ' + file_name + '.png ' + file_name + receive_sensitivity + 'dBm.tif'
+    wld2gtif = 'gdal_translate -a_nodata 255 -expand gray -of GTiff ' + file_name + '.png ' + file_name + str(receive_sensitivity) + 'dBm.tif'
     print wld2gtif
 
 

--- a/create_output.py
+++ b/create_output.py
@@ -10,7 +10,9 @@ def create(file_name, receive_sensitivity, definition):
 
     #create ppm and KML
     #cpk = 'splat -t ' + file_name + ' -o -c 2.0 '+ file_name + '.ppm -ngs -kml -metric'
-    cpk = 'splat -t ' + file_name + ' -L 8.0 -dbm -db ' + receive_sensitivity + ' -o '+ file_name + '.ppm -kml -metric -ngs'
+    splat = 'splat' if definition!='hd' else 'splat-hd'
+
+    cpk = splat+' -t ' + file_name + ' -L 8.0 -dbm -db ' + str(receive_sensitivity) + ' -o '+ file_name + '.ppm -kml -metric -ngs'
 
     print '===================='
     print cpk

--- a/create_output_from_dir.py
+++ b/create_output_from_dir.py
@@ -10,18 +10,23 @@ receive_sensitivity = '-110'
 definition='sd'
 
 try:
-    opts, args = getopt.getopt(argv,"h")
+    opts, args = getopt.getopt(sys.argv[1:],"s:h",["sensitivity="])
+    print opts
 except getopt.GetoptError:
+    print sys.argv
+
     sys.exit(2)
 for opt, arg in opts:
     if opt in ("-h"):
         definition="hd"
+    elif opt in("-s","--sensitivity"):
+        receive_sensitivity = int(arg)
 
-if len(sys.argv) == 2:
-    if int(sys.argv[1]) < 0:
-        receive_sensitivity = str(sys.argv[1])
+#force sensititive to a negitive, so cli can pass positive numbers
+if receive_sensitivity >= 0:
+    receive_sensitivity = (0 - (receive_sensitivity))
 
-print 'modelling with a receive sensitivity of: ' + receive_sensitivity + ' dBm'
+print 'modelling with a receive sensitivity of: ' + str(receive_sensitivity) + ' dBm'
 
 
 myglob = '*.qth'

--- a/create_output_from_dir.py
+++ b/create_output_from_dir.py
@@ -4,10 +4,18 @@
 import sys
 import create_output
 import os
-import glob
+import glob, getopt
 
 receive_sensitivity = '-110'
+definition='sd'
 
+try:
+    opts, args = getopt.getopt(argv,"h")
+except getopt.GetoptError:
+    sys.exit(2)
+for opt, arg in opts:
+    if opt in ("-h"):
+        definition="hd"
 
 if len(sys.argv) == 2:
     if int(sys.argv[1]) < 0:
@@ -23,7 +31,7 @@ myglob = '*.qth'
 i=0
 for filename in glob.glob('*.qth'):
     stub = filename[:-4]
-    create_output.create(stub, receive_sensitivity)
+    create_output.create(stub, receive_sensitivity, definition)
     i+=1
     if i>300:
         break


### PR DESCRIPTION
Pass -h to enable splat-hd
Receive_sensitivity would now be controlled with -s, or --sensitivity
Positive receive_sensitivity numbers are forced to negative

./create_output_from_folder.py -h -s -105
./create_output_from_folder.py -h --sensitivity=105
./create_output_from_folder.py -hs -105
./create_output_from_folder.py -s 105

etc etc

I'll leave the documentation up to you, since I'm a good bloke 
